### PR TITLE
Does this prevent 400 errors from Cloudflare?

### DIFF
--- a/lib/async/discord/client.rb
+++ b/lib/async/discord/client.rb
@@ -12,7 +12,7 @@ module Async
 	module Discord
 		class Client < Async::REST::Resource
 			ENDPOINT = Async::HTTP::Endpoint.parse("https://discord.com/api/v10/")
-			USER_AGENT = "#{self.name} (https://github.com/socketry/async-discord, v#{Async::Discord::VERSION})"
+			USER_AGENT = "DiscordBot (https://github.com/socketry/async-discord, v#{Async::Discord::VERSION})"
 			
 			def authenticated(bot: nil, bearer: nil)
 				headers = {}


### PR DESCRIPTION
I noticed these errors in CI:

```
    expect #<Async::Discord::Guilds "/api/v10/users/@me/guilds" value=nil> not to
        be empty?
            ⚠ Async::REST::ResponseError: 400 HTTP/2: <html>
            <head><title>400 Bad Request</title></head>
            <body>
            <center><h1>400 Bad Request</h1></center>
            <hr><center>cloudflare</center>
            </body>
            </html>
```

The documentation for the user agent might explicitly require the string `DiscordBot`: https://discord.com/developers/docs/reference#user-agent-user-agent-example

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
