### PR TITLE
feat: add application and application commands support

### DIFF
--- a/lib/async/discord/application.rb
+++ b/lib/async/discord/application.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "representation"
+require_relative "application_commands"
+
+module Async
+	module Discord
+		# Represents an application.
+		class Application < Representation
+			# The unique identifier for this application.
+			def id
+				self.value[:id]
+			end
+
+			# The name of this application.
+			def name
+				self.value[:name]
+			end
+
+			# The global commands for this application.
+			def commands
+				path = @resource.path.gsub("@me", id) + "/commands"
+				ApplicationCommands.new(@resource.with(path: path))
+			end
+		end
+	end
+end

--- a/lib/async/discord/application_commands.rb
+++ b/lib/async/discord/application_commands.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Async
+	module Discord
+		# Represents an application command.
+		class ApplicationCommand < Representation
+			# The unique identifier for this application command.
+			def id
+				self.value[:id]
+			end
+
+			# The name of this application command.
+			def name
+				self.value[:name]
+			end
+
+			# Update this application command.
+			def update(payload)
+				self.class.patch(@resource, payload)
+			end
+
+			# Delete this application command.
+			def delete
+				self.class.delete(@resource)
+			end
+		end
+
+		# Represents a collection of application commands.
+		class ApplicationCommands < Representation
+			# Create a new application command.
+			def create(payload)
+				ApplicationCommand.post(@resource, payload)
+			end
+
+			# Enumerate over each command.
+			def each(&block)
+				return to_enum unless block_given?
+
+				self.value.each do |value|
+					yield ApplicationCommand.new(@resource.with(path: value[:id]), value: value)
+				end
+			end
+		end
+	end
+end

--- a/lib/async/discord/client.rb
+++ b/lib/async/discord/client.rb
@@ -7,6 +7,7 @@ require_relative "representation"
 
 require_relative "guilds"
 require_relative "gateway"
+require_relative "application"
 
 module Async
 	module Discord
@@ -14,10 +15,10 @@ module Async
 		class Client < Async::REST::Resource
 			# The default endpoint for Discord.
 			ENDPOINT = Async::HTTP::Endpoint.parse("https://discord.com/api/v10/")
-			
+
 			# The default user agent for this client.
 			USER_AGENT = "#{self.name} (https://github.com/socketry/async-discord, v#{Async::Discord::VERSION})"
-			
+
 			# Authenticate the client, either with a bot or bearer token.
 			#
 			# @parameter bot [String] The bot token.
@@ -25,9 +26,9 @@ module Async
 			# @returns [Client] a new client with the given authentication.
 			def authenticated(bot: nil, bearer: nil)
 				headers = {}
-				
+
 				headers["user-agent"] ||= USER_AGENT
-				
+
 				if bot
 					headers["authorization"] = "Bot #{bot}"
 				elsif bearer
@@ -35,23 +36,33 @@ module Async
 				else
 					raise ArgumentError, "You must provide either a bot or bearer token!"
 				end
-				
+
 				return self.with(headers: headers)
 			end
-			
+
 			# @returns [Guilds] a collection of guilds the bot is a member of.
 			def guilds
 				Guilds.new(self.with(path: "users/@me/guilds"))
 			end
-			
+
 			# @returns [Gateway] the gateway for the bot.
 			def gateway
 				Gateway.new(self.with(path: "gateway/bot"))
 			end
-			
+
 			# @returns [Channel] a channel by its unique identifier.
 			def channel(id)
 				Channel.new(self.with(path: "channels/#{id}"))
+			end
+
+			# @returns [Application] the application.
+			def application(id)
+				Application.new(self.with(path: "applications/#{id}"))
+			end
+
+			# @returns [Application] the application which is currently authenticated.
+			def current_application
+				application("@me")
 			end
 		end
 	end

--- a/test/async/discord/client.rb
+++ b/test/async/discord/client.rb
@@ -7,13 +7,22 @@ require "async/discord/client_context"
 
 describe Async::Discord::Client do
 	include Async::Discord::ClientContext
-	
+
 	with "#guilds" do
 		it "can list guilds" do
 			guilds = client.guilds
-			
+
 			expect(guilds).to be_a(Async::Discord::Guilds)
 			expect(guilds).not.to be(:empty?)
+		end
+	end
+
+	with "#current_application" do
+		it "can get the current application" do
+			application = client.current_application
+
+			expect(application).to be_a(Async::Discord::Application)
+			expect(application.id).to be_kind_of(Integer)
 		end
 	end
 end


### PR DESCRIPTION
For my Discord Bot, I need to create an "application command" to allow a user to trigger the bot with `/help` and interact with it.

* Add `Client#application(id)` to get application by id
* Add `Client#current_application` to get application by `@me` shortcut (auto-replace id when use `#commands`)
* Add `Application#commands` to get global application commands
* Add `ApplicationCommands#create(payload)` to allow create new command
* Add `ApplicationCommand#update(payload)` to allow update command itself
* Add `ApplicationCommand#delete` to allow the delete command itself

> Not sure which style is preferred, make a minimal workable implementation

## Types of Changes

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
